### PR TITLE
Added compatibility with new Docker (compose) version and improved haveOrder helper.

### DIFF
--- a/.env-default
+++ b/.env-default
@@ -32,7 +32,7 @@ K6_HTTP_DEBUG=
 # This variable is the path to the script file that K6 will execute during the test.
 # The test script is a JavaScript file that contains the test scenarios and configuration for the test.
 # This variable should be set to the path of the script file that should be run.
-K6_SCRIPT=tests/example-scenario.js
+K6_SCRIPT=tests/abstract-scenario.js
 
 ###################################
 # Spryker Test Framework Settings #

--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -85,7 +85,17 @@ build_k6_docker_command() {
             return 1;
     fi
 
-    command="docker-compose run --rm \
+    if docker compose version >/dev/null 2>&1; then
+        DOCKER_COMPOSE="docker compose"
+    # Check if 'docker-compose' is available
+    elif docker-compose --version >/dev/null 2>&1; then
+        DOCKER_COMPOSE="docker-compose"
+    else
+        echo "Neither 'docker compose' nor 'docker-compose' is available. Please install one of them."
+        exit 1
+    fi
+
+    command="$DOCKER_COMPOSE run --rm \
             -v $(pwd):/scripts \
             -u $(id -u):$(id -g) \
             -e 'SPRYKER_TEST_RUN_ID=$testRunId' \

--- a/tests/cross-product/sapi/scenarios/checkout/shared-checkout-scenario.js
+++ b/tests/cross-product/sapi/scenarios/checkout/shared-checkout-scenario.js
@@ -27,7 +27,7 @@ export class SharedCheckoutScenario extends AbstractScenario {
         }
 
         const checkoutResponse = this.http.sendPostRequest(
-            this.http.url`${this.getStorefrontApiBaseUrl()}/checkout?include=orders`,
+            this.http.url`${this.getStorefrontApiBaseUrl()}/checkout`,
             JSON.stringify(this._getCheckoutData(cartId, customerEmail, isMpPaymentProvider)),
             requestParams,
             false

--- a/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI15-cart-reorder_50.js
+++ b/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI15-cart-reorder_50.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Reorder
-    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI19-cart-reorder_70.js
+++ b/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI19-cart-reorder_70.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Reorder
-    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI23-cart-reorder_50.js
+++ b/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI23-cart-reorder_50.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Reorder
-    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI27-cart-reorder_70.js
+++ b/tests/suite/sapi/tests/cart-reorder/SUITE-SAPI27-cart-reorder_70.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Reorder
-    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedCartReorderScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI16-start-order-amendment_50.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI16-start-order-amendment_50.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Edit an order
-    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI18-finish-order-amendment_50.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI18-finish-order-amendment_50.js
@@ -55,7 +55,7 @@ export function execute(data) {
     // Edit an order
     const cartReorderResponseJson = sharedOrderAmendmentScenario.haveOrderAmendment(
         customerEmail,
-        checkoutResponseJson.data.relationships.orders.data[0].id
+        checkoutResponseJson.data.attributes.orderReference
     );
 
     // Place an updated order

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI20-start-order-amendment_70.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI20-start-order-amendment_70.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Edit an order
-    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI22-finish-order-amendment_70.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI22-finish-order-amendment_70.js
@@ -55,7 +55,7 @@ export function execute(data) {
     // Edit an order
     const cartReorderResponseJson = sharedOrderAmendmentScenario.haveOrderAmendment(
         customerEmail,
-        checkoutResponseJson.data.relationships.orders.data[0].id
+        checkoutResponseJson.data.attributes.orderReference
     );
 
     // Place an updated order

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI24-start-order-amendment_50.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI24-start-order-amendment_50.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Edit an order
-    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI26-finish-order-amendment_50.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI26-finish-order-amendment_50.js
@@ -55,7 +55,7 @@ export function execute(data) {
     // Edit an order
     const cartReorderResponseJson = sharedOrderAmendmentScenario.haveOrderAmendment(
         customerEmail,
-        checkoutResponseJson.data.relationships.orders.data[0].id
+        checkoutResponseJson.data.attributes.orderReference
     );
 
     // Place an updated order

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI28-start-order-amendment_70.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI28-start-order-amendment_70.js
@@ -46,5 +46,5 @@ export function execute(data) {
     const checkoutResponseJson = sharedCheckoutScenario.haveOrder(customerEmail, quoteIds[quoteIndex], false);
 
     // Edit an order
-    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.relationships.orders.data[0].id, thresholdTag);
+    sharedOrderAmendmentScenario.execute(customerEmail, checkoutResponseJson.data.attributes.orderReference, thresholdTag);
 }

--- a/tests/suite/sapi/tests/order-amendment/SUITE-SAPI30-finish-order-amendment_70.js
+++ b/tests/suite/sapi/tests/order-amendment/SUITE-SAPI30-finish-order-amendment_70.js
@@ -55,7 +55,7 @@ export function execute(data) {
     // Edit an order
     const cartReorderResponseJson = sharedOrderAmendmentScenario.haveOrderAmendment(
         customerEmail,
-        checkoutResponseJson.data.relationships.orders.data[0].id
+        checkoutResponseJson.data.attributes.orderReference
     );
 
     // Place an updated order


### PR DESCRIPTION
## PR Description
- Added compatibility with new Docker (compose) version
- Replaced usage of POST `/checkout?include=orders` to POST `/checkout`, the response has order reference.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
